### PR TITLE
fixed bug in get_design

### DIFF
--- a/glam/utils.py
+++ b/glam/utils.py
@@ -104,7 +104,7 @@ def get_design(model):
     subjects = subject_idx.unique()
 
     design = dict()
-    design['factors'] = [value for key, value in model.depends_on.items()]
+    design['factors'] = list({value for key, value in model.depends_on.items()})
     design['factor_conditions'] = {factor: model.data[factor].unique()
                                    for factor in design['factors']}
 


### PR DESCRIPTION
if multiple parameters depend on the same factor, design should only list the factor once. otherwise this leads to undesired effects in get_estimates